### PR TITLE
Add provision for optional download headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
+language: ruby
 rvm:
-- 1.9.3
-- 2.2.3
+  - 1.9.3
+  - 2.2.3
 env:
+  global: CLOUDINARY_URL=[secure]
   matrix:
     secure: OTtg+CpNgfqJYqJk4rRZRvljss2p6nLTgBLrdUt/4hpSFLFueo0m7Jdu2zeEDPLEzMKo6zZlBp1/BPjCHtnjda7qpOQpMutEzD5EG60BG5LiMDsoAHL6apiL4zNUy8Sjcp/QslpKRozcYzogHjCnxM8RtSnW9wqiCehM5yivlj4JwU/e2x7XZGRbwW2jj4kr/BAdylYYftAaVOrl/3vqngE2tciq6YRL5GFR6o1L5ty435jsyDwEWAPs6vTLwJuEmPLJ4pEOVPOI08zOgVWKHyAWiCc7WYyBxKDmDUU9Xth922ko7nhptQUJeJuxh2dTvrPuTkibNzX1QLugX8RwzJ7pXG9iuhx14lmFbfZZtl+g2SEh5Hem5GFCVOlxpULuxZUKDcNwYURWwuoeBYpGOrOu7xn70o6cF3bNfenUJEl/ts1YgAZ/pcHmbeW95ovb+vTHj8uPk1J17FKOtXjbgblzYLwrl68ika1QfWJEYq1DcI7BT7AwsEeThPmvQ03y+lH8DrYQVprzTpjGICvMyMQSZdA8woXMeEFV0CzKew1+Q0JgjLpYDTQ6U51HEvzCZFTNoN2ZDdsdMRtkxmjBwgEQAY5+SA5icI6/uxAvloScl+7SnNiAhqyPaA2YlwZ/xhI8plvydkmK805Z1uZztGUNu0yn47FzGDC286RF/rI=
 script: bundle exec rspec

--- a/lib/cloudinary/carrier_wave/remote.rb
+++ b/lib/cloudinary/carrier_wave/remote.rb
@@ -1,5 +1,5 @@
 module Cloudinary::CarrierWave
-  def download!(uri)
+  def download!(uri, _headers = {})
     return super if !self.cloudinary_should_handle_remote?
     if respond_to?(:process_uri)
       uri = process_uri(uri)


### PR DESCRIPTION
In version 1.0.0 of carrierwave the public interface of
`CarrierWave::Uploader::Download#download!`
[changed](https://github.com/carrierwaveuploader/carrierwave/commit/62667955c7ba3d2789944b0598f5b3c79ae1b3ea#diff-323aa4ff2c24aebdbdd5f21fb1195886R71)
to include an optional headers parameter. This brings back compatibility with
carrierwave.