### PR TITLE
Switch alias_method_chain to alias_method to support Rails version >5.1

### DIFF
--- a/lib/cloudinary/helper.rb
+++ b/lib/cloudinary/helper.rb
@@ -268,13 +268,12 @@ module CloudinaryHelper
       if !method_defined?(:image_tag)
         include ActionView::Helpers::AssetTagHelper
       end
-      if defined?(::Rails::VERSION::MAJOR) && ::Rails::VERSION::MAJOR > 2 && Cloudinary.config.enhance_image_tag
-        alias_method_chain :image_tag, :cloudinary unless public_method_defined? :image_tag_without_cloudinary
-        alias_method_chain :image_path, :cloudinary unless public_method_defined? :image_path_without_cloudinary
-      else
-        alias_method :image_tag_without_cloudinary, :image_tag unless public_method_defined? :image_tag_without_cloudinary
-        alias_method :image_path_without_cloudinary, :image_path unless public_method_defined? :image_path_without_cloudinary
-      end
+      alias_method :image_tag_without_cloudinary, :image_tag unless public_method_defined? :image_tag_without_cloudinary
+      alias_method :image_path_without_cloudinary, :image_path unless public_method_defined? :image_path_without_cloudinary
+      if Cloudinary.config.enhance_image_tag
+        alias_method :image_tag, :image_tag_with_cloudinary
+        alias_method :image_path, :image_path_with_cloudinary
+      end    
     end
   end
 


### PR DESCRIPTION
When we run rspec, we get a couple of deprecation warnings:

```
> bundle exec rspec
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in included at ~/.gem/ruby/2.3.3/bundler/gems/cloudinary_gem-8d09a6fb3c41/lib/cloudinary/helper.rb:272)
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in included at ~/.gem/ruby/2.3.3/bundler/gems/cloudinary_gem-8d09a6fb3c41/lib/cloudinary/helper.rb:273)
```

This PR brings across the fix for the deprecation warnings from the gem's main repository.

You can find original PR [here](https://github.com/cloudinary/cloudinary_gem/pull/243).